### PR TITLE
Fixed empty iterators together with total='noinfer'

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -38,6 +38,7 @@ class ProgressBar():
     def __iter__(self):
         if self.total != 0: self.update(0)
         try:
+            i = -1
             for i,o in enumerate(self.gen):
                 if self.total and i >= self.total: break
                 yield o


### PR DESCRIPTION
You can trigger the error like this:
```
for x in progress_bar([], total='noinfer'):
    pass
```

The fix is to initialize the counter outside of the loop so it work even if no iterations were done.