### PR TITLE
Fix AttributeError in NBMasterBar.show() when self.out is not initialized

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -231,7 +231,7 @@ class NBMasterBar(MasterBar):
         self.inner_dict['text'] = Div(*self.text_parts)
         children = [getattr(item, 'progress', None) or item for n in self.order
             if (item := self.inner_dict.get(n))]
-        self.out.update(Div(*children))
+        if hasattr(self, 'out'): self.out.update(Div(*children))
 
     def write(self, line, table=False):
         if table: self.lines.append(line); self.text_parts = [text2html_table(self.lines)]


### PR DESCRIPTION
### Problem

In certain Jupyter environments (like VS Code and some local JupyterLab setups), calling `learn.fine_tune()` in fastai crashes with:
```
AttributeError: 'NBMasterBar' object has no attribute 'out'
```

This occurs because `show()` is called during the `before_fit` event (via `write()`), which happens before `on_iter_begin()` initializes `self.out`.

This patch adds `hasattr(self, 'out')` check before calling `self.out.update()` in the `show()` method which is consistent with how `on_iter_end()` and `on_interrupt()` already handle this attribute.

### Current workarounds

Users currently work around this by:
- Using `with learn.no_bar(): learn.fine_tune(1)`
- Or by completely disabling progress callbacks

This fix eliminates the need for these workarounds.

I tested this locally in Jupyter environment with fastai/fastbook Chapter 1 where it previously crashed. After applying this fix, the progress bars display correctly.