### PR TITLE
fix: 'NBMasterBar' object has no attribute 'out'

### DIFF
--- a/fastprogress/fastprogress.py
+++ b/fastprogress/fastprogress.py
@@ -231,7 +231,7 @@ class NBMasterBar(MasterBar):
         self.inner_dict['text'] = Div(*self.text_parts)
         children = [getattr(item, 'progress', None) or item for n in self.order
             if (item := self.inner_dict.get(n))]
-        self.out.update(Div(*children))
+        if hasattr(self, 'out'): self.out.update(Div(*children))
 
     def write(self, line, table=False):
         if table: self.lines.append(line); self.text_parts = [text2html_table(self.lines)]


### PR DESCRIPTION
This fixes:

```text
File ~/dev/.venv/lib/python3.13/site-packages/fastai/learner.py:272, in Learner.fit(self, n_epoch, lr, wd, cbs, reset_opt, start_epoch)
    270 self.opt.set_hypers(lr=self.lr if lr is None else lr)
    271 self.n_epoch = n_epoch
...
    233     if (item := self.inner_dict.get(n))]
--> 234 self.out.update(Div(*children))

AttributeError: Exception occured in `ProgressCallback` when calling event `before_fit`:
	'NBMasterBar' object has no attribute 'out'
```